### PR TITLE
unit + integration tests support for Corrosion v0.5

### DIFF
--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -869,6 +869,36 @@ function(_add_cargo_build out_cargo_build_out_dir)
     )
     add_dependencies(cargo-build_${target_name} _cargo-build_${target_name})
 
+    add_test(NAME cargo-test-${target_name}
+    # Test crate
+    COMMAND
+        ${CMAKE_COMMAND} -E env
+            "${build_env_variable_genex}"
+            "${global_rustflags_genex}"
+            "${cargo_target_linker}"
+            "${corrosion_cc_rs_flags}"
+            "${cargo_library_path}"
+            "CORROSION_BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}"
+            "CARGO_BUILD_RUSTC=${_CORROSION_RUSTC}"
+        "${cargo_bin}"
+            test 
+            ${target_name}
+            ${_CORROSION_VERBOSE_OUTPUT_FLAG}
+            ${all_features_arg}
+            ${no_default_features_arg}
+            ${features_genex}
+            --package ${package_name}
+            --manifest-path "${path_to_toml}"
+            --target-dir "${cargo_target_dir}"
+            ${cargo_profile}
+            ${flags_genex}
+            # Any arguments to cargo must be placed before this line
+            #${local_rustflags_delimiter}
+            #${local_rustflags_genex}
+            WORKING_DIRECTORY "${workspace_toml_dir}"
+      COMMAND_EXPAND_LISTS
+    )
+
     # Add custom target before actual build that user defined custom commands (e.g. code generators) can
     # use as a hook to do something before the build. This mainly exists to not expose the `_cargo-build` targets.
     add_custom_target(cargo-prebuild_${target_name})

--- a/cmake/Corrosion.cmake
+++ b/cmake/Corrosion.cmake
@@ -646,6 +646,8 @@ function(_add_cargo_build out_cargo_build_out_dir)
         set(cargo_rustc_filter "--lib")
     elseif("bin" IN_LIST target_kinds)
         set(cargo_rustc_filter "--bin=${target_name}")
+    elseif("test" IN_LIST target_kinds)
+        set(cargo_rustc_filter "--test=${target_name}")
     else()
         message(FATAL_ERROR "TARGET_KINDS contained unknown kind `${target_kind}`")
     endif()
@@ -869,7 +871,7 @@ function(_add_cargo_build out_cargo_build_out_dir)
     )
     add_dependencies(cargo-build_${target_name} _cargo-build_${target_name})
 
-    add_test(NAME cargo-test-${target_name}
+    add_test(NAME cargo-test_${target_name}
     # Test crate
     COMMAND
         ${CMAKE_COMMAND} -E env
@@ -881,8 +883,8 @@ function(_add_cargo_build out_cargo_build_out_dir)
             "CORROSION_BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}"
             "CARGO_BUILD_RUSTC=${_CORROSION_RUSTC}"
         "${cargo_bin}"
-            test 
-            ${target_name}
+            test
+            ${cargo_rustc_filter}
             ${_CORROSION_VERBOSE_OUTPUT_FLAG}
             ${all_features_arg}
             ${no_default_features_arg}

--- a/cmake/CorrosionGenerator.cmake
+++ b/cmake/CorrosionGenerator.cmake
@@ -160,7 +160,7 @@ function(_generator_add_package_targets)
             list(APPEND corrosion_targets ${target_name})
             set_property(TARGET "${target_name}" PROPERTY INTERFACE_COR_CARGO_PACKAGE_NAME "${package_name}" )
         # Note: "bin" is mutually exclusive with "staticlib/cdylib", since `bin`s are seperate crates from libraries.
-        elseif("bin" IN_LIST kinds)
+        elseif("bin" IN_LIST kinds )
             set(bin_byproduct "")
             set(pdb_byproduct "")
             add_executable(${target_name} IMPORTED GLOBAL)
@@ -194,8 +194,35 @@ function(_generator_add_package_targets)
             endif()
             list(APPEND corrosion_targets ${target_name})
             set_property(TARGET "${target_name}" PROPERTY INTERFACE_COR_CARGO_PACKAGE_NAME "${package_name}" )
+        elseif("test" IN_LIST kinds)
+            # tests, namely integration tests, unit tests are directly within lib and bin
+            set(bin_byproduct "")
+            set(pdb_byproduct "")
+            add_executable(${target_name} IMPORTED GLOBAL)
+            _corrosion_initialize_properties(${target_name})
+            _corrosion_add_bin_target("${workspace_manifest_path}" "${target_name}"
+                "bin_byproduct" "pdb_byproduct"
+            )
+
+            set(byproducts "")
+            list(APPEND byproducts "${bin_byproduct}" "${pdb_byproduct}")
+
+            set(cargo_build_out_dir "")
+            _add_cargo_build(
+                cargo_build_out_dir
+                PACKAGE "${package_name}"
+                TARGET "${target_name}"
+                MANIFEST_PATH "${manifest_path}"
+                WORKSPACE_MANIFEST_PATH "${workspace_manifest_path}"
+                TARGET_KINDS "test"
+                BYPRODUCTS "${byproducts}"
+                # Optional
+                ${no_linker_override}
+            )
+            list(APPEND corrosion_targets ${target_name})
+            set_property(TARGET "${target_name}" PROPERTY INTERFACE_COR_CARGO_PACKAGE_NAME "${package_name}" )
         else()
-            # ignore other kinds (like examples, tests, build scripts, ...)
+            # ignore other kinds (like examples,  build scripts, ...)
         endif()
     endforeach()
 


### PR DESCRIPTION
For each target we add a ctest target to run unit tests and we register newly the cargo integration tests as part of the build.

examples and doctests are not supported yet but could be added in a similar fashion later on.